### PR TITLE
feature/model_improvements_tf2.15_updates

### DIFF
--- a/Prod5.1-FD/analysis/plot_1d_vertex_resolutions.py
+++ b/Prod5.1-FD/analysis/plot_1d_vertex_resolutions.py
@@ -76,20 +76,12 @@ df = pd.concat([df, vtx_abs_diff_ea_temp, vtx_abs_diff_model_temp, df_mode], axi
 print("Creating 'df_modes'...........")
 df_modes = list()
 for i in range(len(int_modes)):
-    print('Int Type, Code: ', utils.plot.ModeType.name(i), ' ', int_modes[i])
     df_modes.append(df[df['Mode'] == i])
 # assert are no kUnknownMode events...
 assert (len(df[df['Mode'] == -1]) == 0)  # 'there are Unknown events. Stopping'
 
 ###################
 # TODO: not essential, but in case we want to make distributions from each neutrino flavor
-# and could make a list of dfs... need to extract the PDG too...
-# make two new dataframes: one Nonswap, one Fluxswap.
-# df_nonswap = df[df['PDG'] == 14]
-# df_fluxswap = df[df['PDG'] == 12]
-# print('Nonswap entries: ', len(df_nonswap))
-# print('Fluxswap entries: ', len(df_fluxswap))
-####################
 
 # output directory
 print('Output Directory: ', args.outdir)
@@ -151,6 +143,7 @@ for ext in ['pdf', 'png']:
     fig_res_int_EA.savefig(
         OUTDIR + '/plot_{}_allmodes_Resolution_{}_ElasticArms.'.format(
             str_det_horn, C) + ext, dpi=300)
+plt.close(fig_res_int_EA)
 
 # Model Prediction, ONLY
 # plot the resolution of the vertex for each interaction type on single plot.
@@ -178,6 +171,7 @@ for ext in ['pdf', 'png']:
     fig_res_int_Model.savefig(
         OUTDIR + '/plot_{}_allmodes_Resolution_{}_ModelPred.'.format(
             str_det_horn, C) + ext, dpi=300)
+plt.close(fig_res_int_Model)
 # ------------- All interactions separate model end -------------
 
 # ------------ Individual interactions Overlaid, Model + E.A., [Abs, Res, RelRes]  -------------
@@ -209,6 +203,7 @@ plt.subplots_adjust(bottom=0.15, left=0.15)
 for ext in ['pdf', 'png']:
     fig_resolution.savefig(OUTDIR + '/plot_{}_allmodes_{}_AbsResolution.'.
                            format(str_det_horn, C) + ext, dpi=300)
+plt.close(fig_resolution)
 
 # Resolution
 # plot the (reco - true) vertex difference for both: Elastic Arms and Model Prediction
@@ -243,6 +238,7 @@ for ext in ['pdf', 'png']:
     fig_resolution.savefig(
         OUTDIR + '/plot_{}_allmodes_{}_Resolution.'.format(str_det_horn, C) + ext,
         dpi=300)
+plt.close(fig_resolution)
 
 # Relative Resolution
 # plot the (reco - true)/true vertex difference for both:
@@ -266,7 +262,7 @@ plt.ylabel('Events')
 plt.text(0.05, hist_EA_all_relres.max() * 0.7, '{} {}\nAll Interactions\n {} coordinate'.format(DET, HORN, C),
          fontsize=8)
 plt.text(0.05,hist_EA_all_relres.max() * 0.5,
-         f'Mean E.A.: {mean_float_EA_all_relres:.3f} cm\nMean Model: {mean_float_Model_all_relres:.3f} cm',
+         f'Mean E.A.: {mean_float_EA_all_relres:.2f} cm\nMean Model: {mean_float_Model_all_relres:.2f} cm',
          fontsize=8)
 plt.grid(color='black', linestyle='--', linewidth=0.25, axis='both')
 plt.legend(loc='upper right')
@@ -276,6 +272,7 @@ for ext in ['pdf', 'png']:
     fig_resolution.savefig(
         OUTDIR + '/plot_{}_allmodes_{}_RelResolution.'.format(
             str_det_horn, C) + ext, dpi=300)
+plt.close(fig_resolution)
 # ------------ Individual interactions Overlaid, Model + E.A., [Abs, Res, RelRes]  -------------
 
 
@@ -316,7 +313,7 @@ for i in range(0, len(int_modes)):
     for ext in ['pdf', 'png']:
         fig_resolution_int.savefig(OUTDIR + '/plot_{}_{}_AbsResolution_{}.'.
                                    format(str_det_horn, C, utils.plot.ModeType.name(i)) + ext, dpi=300)
-
+    plt.close(fig_resolution_int)
 
 # FOR EACH INTERACTION TYPE
 # plot the (reco - true) resolution of the vertex
@@ -360,7 +357,7 @@ for i in range(0, len(int_modes)):
         fig_res_int.savefig(OUTDIR + '/plot_{}_{}_Resolution_{}.'.format(str_det_horn,
                                                                               C,
                                                                               utils.plot.ModeType.name(i)) + ext, dpi=300)
-
+        plt.close(fig_res_int)
 
 # FOR EACH INTERACTION TYPE
 # plot the relative resolution (reco - true)/true
@@ -391,7 +388,7 @@ for i in range(0, len(int_modes)):
     plt.ylabel('Events')
     plt.title('{} Interactions'.format(utils.plot.ModeType.name(i)))
     plt.text(0.05, hist_EA.max() * 0.55, '{} {}\n{} coordinate'.format(DET, HORN, C), fontsize=8)
-    plt.text(0.05, hist_EA.max() * 0.4, 'Mean E.A.: {:.3f} cm\nMean Model: {:.3f} cm'.format(mean_EA_int_relres, mean_Model_int_relres), fontsize=8)
+    plt.text(0.05, hist_EA.max() * 0.4, 'Mean E.A.: {:.2f} cm\nMean Model: {:.2f} cm'.format(mean_EA_int_relres, mean_Model_int_relres), fontsize=8)
     plt.legend(loc='upper right')
     plt.subplots_adjust(bottom=0.15, left=0.15)
     plt.grid(color='black', linestyle='--', linewidth=0.25, axis='both')
@@ -399,3 +396,6 @@ for i in range(0, len(int_modes)):
     for ext in ['pdf', 'png']:
         fig_res_int.savefig(OUTDIR + '/plot_{}_{}_RelResolution_{}.'.
                             format(str_det_horn, C, utils.plot.ModeType.name(i)) + ext, dpi=300)
+    plt.close(fig_res_int)
+
+print('Done!')

--- a/Prod5.1-FD/model-prediction/model_predict_coordinates_xyz.py
+++ b/Prod5.1-FD/model-prediction/model_predict_coordinates_xyz.py
@@ -17,7 +17,7 @@ import argparse
 import numpy as np
 import pandas as pd
 import pickle
-from tensorflow.python.keras.models import load_model
+from tensorflow.keras.models import load_model
 import os
 import time
 

--- a/Prod5.1-FD/training/create_slurm_script_training.sh
+++ b/Prod5.1-FD/training/create_slurm_script_training.sh
@@ -12,6 +12,12 @@
 DATE=$(date +%m-%d-%Y.%H.%M.%S)
 echo "current date: " $DATE
 
+# Ensure exactly 5 arguments are provided
+if [[ $# -ne 5 ]]; then
+    echo "Usage: $0 <COORDINATE> <DET> <HORN> <FLUX> <EPOCHS>"
+    echo "Example: $0 xyz FD FHC Fluxswap 100"
+    return 0
+fi
 
 COORDINATE=$1 # x, y, z, or xyz
 DET=$2        # ND or FD
@@ -65,13 +71,13 @@ cat > $slurm_dir/submit_slurm_${outputfile}.sh <<EOS
 ### better for a single "task"
 #SBATCH --ntasks=1         # Single task
 #SBATCH --cpus-per-task=8  # Allocate 8 CPUs for better parallel processing
-#SBATCH --mem=380000M      # bc RealMemory=384896M for gpu201901
+#SBATCH --mem=384000M      # bc RealMemory=384896M for gpu201901
 #SBATCH --gres=gpu:2       # Request 2 GPUs
 
 #SBATCH --nodelist=gpu201901  # compatible with TF 2.3.1
 
 ###SBATCH --mail-type ALL
-###SBATCH --mail-user <WSU email address>
+###SBATCH --mail-user michael.dolce@wichita.edu
 #======================================================================================================================================
 
 # load modules

--- a/Prod5.1-FD/training/create_slurm_script_training.sh
+++ b/Prod5.1-FD/training/create_slurm_script_training.sh
@@ -9,8 +9,6 @@
 #confusion:  from Adam Tygart...don't request multiple nodes if you can't guarantee your code can handle them.
 # -- but sbatch config fails with just 1 node.
 
-# NOTE: the x coordinate has been trained on: --ntasks=8, --mem-per-cpu=22G
-
 DATE=$(date +%m-%d-%Y.%H.%M.%S)
 echo "current date: " $DATE
 
@@ -67,7 +65,7 @@ cat > $slurm_dir/submit_slurm_${outputfile}.sh <<EOS
 ### better for a single "task"
 #SBATCH --ntasks=1         # Single task
 #SBATCH --cpus-per-task=8  # Allocate 8 CPUs for better parallel processing
-#SBATCH --mem=380000M      # bc RealMemory=384896M for gpu201901              #  400G         # Set explicit total memory
+#SBATCH --mem=380000M      # bc RealMemory=384896M for gpu201901
 #SBATCH --gres=gpu:2       # Request 2 GPUs
 
 #SBATCH --nodelist=gpu201901  # compatible with TF 2.3.1
@@ -76,30 +74,28 @@ cat > $slurm_dir/submit_slurm_${outputfile}.sh <<EOS
 ###SBATCH --mail-user <WSU email address>
 #======================================================================================================================================
 
-# create the apptainer
-apptainer exec --nv /opt/beoshock/containers/beoshock_centos-7.9.sif /bin/bash -l <<EOF
-
 # load modules
-module load Python/3.7.4-GCCcore-8.3.0
-module load TensorFlow/2.3.1-fosscuda-2019b-Python-3.7.4
-source /home/k948d562/virtual-envs/VirtualTensorFlow-Abdul/VirtualTensor/bin/activate
-/home/k948d562/virtual-envs/VirtualTensorFlow-Abdul/VirtualTensor/bin/python --version
+module load Python/3.11.5-GCCcore-13.2.0
+source /homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/bin/activate
+/homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/bin/python --version
 
 echo "INFO: appending MLVTX to PYTHONPATH"
-export PYTHONPATH="\\\$PYTHONPATH:/homes/k948d562/ml-vertexing"
-echo "PYTHONPATH is ... \\\$PYTHONPATH"
+unset PYTHONPATH
+export PYTHONPATH="/homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/lib/python3.11/site-packages:/homes/k948d562/ml-vertexing"
+echo "PYTHONPATH is ... \$PYTHONPATH"
 
-echo "/home/k948d562/virtual-envs/VirtualTensorFlow-Abdul/VirtualTensor/bin/python /home/k948d562/ml-vertexing/training/${TRAINING_SCRIPT} --data_train_path ${DATA_TRAIN_PATH} --epochs $EPOCHS"
+export LD_LIBRARY_PATH="/homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/lib:\$LD_LIBRARY_PATH"
+
+echo "/homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/bin/python /home/k948d562/ml-vertexing/training/${TRAINING_SCRIPT} --data_train_path ${DATA_TRAIN_PATH} --epochs $EPOCHS"
 #run python script
-/home/k948d562/virtual-envs/VirtualTensorFlow-Abdul/VirtualTensor/bin/python /home/k948d562/ml-vertexing/training/${TRAINING_SCRIPT} --data_train_path ${DATA_TRAIN_PATH} --epochs $EPOCHS
+/homes/k948d562/virtual-envs/py3.11-pipTF2.15.0/bin/python /home/k948d562/ml-vertexing/training/${TRAINING_SCRIPT} --data_train_path ${DATA_TRAIN_PATH} --epochs $EPOCHS
 
-EOF
 
 # After the job finishes, log resource usage
-sleep 60
+sleep 120
 echo "Job completed. Logging resource usage:"                    >> ${LOG_OUTDIR}/${outputfile}.out
-echo "sacct -j \$SLURM_JOB_ID --format=JobID,JobName,MaxRSS,MaxVMSize,NodeList "    >> ${LOG_OUTDIR}/${outputfile}.out
-sacct -j \$SLURM_JOB_ID --format=JobID,JobName,MaxRSS,MaxVMSize,NodeList >> ${LOG_OUTDIR}/${outputfile}.out
+echo "sacct -j \$SLURM_JOB_ID --format=JobID,JobName,MaxRSS,MaxVMSize,NodeList,Elapsed,State "    >> ${LOG_OUTDIR}/${outputfile}.out
+sacct -j \$SLURM_JOB_ID --format=JobID,JobName,MaxRSS,MaxVMSize,NodeList,Elapsed,State >> ${LOG_OUTDIR}/${outputfile}.out
 
 EOS
 

--- a/Prod5.1-FD/training/small-scale-testing/xyz_vertex_training_testsize.py
+++ b/Prod5.1-FD/training/small-scale-testing/xyz_vertex_training_testsize.py
@@ -210,8 +210,8 @@ save_metric_dir = f'/home/k948d562/output/metrics/small-scale-testing/{output_na
 # Evaluate the test set
 print('METRICS:')
 evaluation = utils.model.evaluate_model(model_regCNN,
+                                        data_train,
                                         data_test,
-                                        keep_drop_evts,
                                         save_metric_dir)
 print(metrics.head())
 metrics.to_csv(save_metric_dir + '/metrics_{}.csv'.format(output_name), index_label='epoch')

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -172,7 +172,10 @@ save_metric_dir = '/home/k948d562/output/metrics/'
 
 # Evaluate the test set
 print('METRICS:')
-evaluation = utils.model.evaluate_model(model_regCNN, data_test, save_metric_dir)
+evaluation = utils.model.evaluate_model(model_regCNN,
+                                        data_train,
+                                        data_test,
+                                        save_metric_dir)
 print(metrics.head())
 metrics.to_csv(save_metric_dir + '/metrics_{}.csv'.format(output_name), index_label='epoch')
 print('Saved metrics to: ', save_metric_dir + '/metrics_{}.csv'.format(output_name))

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -117,9 +117,10 @@ print('After, vtx_x_pixelmap: ', vtx_x_pixelmap.shape)
 vtx_coords = np.stack((vtx_x_pixelmap, vtx_y_pixelmap, vtx_z_pixelmap), axis=-1)
 print('vtx_coords: ', vtx_coords.shape)
 
-# Remove the events with un-centered Y pixelmaps
-# TODO: want to return to this. But just want to make sure all is working properly.
-# vtx_coords, events_removed_y_cvnmap = dp.DataCleaning.remove_uncentered_y_cvnmaps(vtx_coords)
+vtx_coords = vtx_coords.astype(np.float16)
+cvnmap_xz = cvnmap_xz.astype(np.float16)
+cvnmap_yz = cvnmap_yz.astype(np.float16)
+
 
 # #### Prepare the Training & Test Sets
 # split the data into training (+ val) and testing sets
@@ -131,8 +132,6 @@ data_train, data_val, data_test = utils.model.Config.create_test_train_val_datas
 
 print('========================================')
 utils.model.Hardware.check_gpu_status()
-print('========================================')
-dp.print_input_data(data_train, data_test, data_val)
 print('========================================')
 
 # ### MultiView Fully Connected Layer Regression CNN Model
@@ -149,7 +148,13 @@ utils.model.Config.compile_model(model_regCNN)
 # print a summary of the model
 print(model_regCNN.summary())
 
-# xyz-coordinate system.
+scaler, data_train, data_val, data_test = utils.model.Config.transform_data(data_train,
+                                                                            data_val,
+                                                                            data_test)
+
+dp.print_input_data(data_train, data_test, data_val)
+
+# fit() the model.
 history = utils.model.train_model(model_regCNN,
                                   data_train,
                                   data_val,

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -17,6 +17,7 @@ from datetime import date
 import numpy as np
 import os
 import pandas as pd
+import pickle
 from tensorflow.keras.optimizers import Adam  # optimizer
 from sklearn.metrics import mean_squared_error, mean_absolute_error, explained_variance_score, r2_score
 import time
@@ -164,7 +165,11 @@ model_regCNN.save(save_model_dir + 'model_{}.h5'.format(output_name))
 print('saved model to: ', save_model_dir + 'model_{}.h5'.format(output_name))
 # Items in the model file: <KeysViewHDF5 ['model_weights', 'optimizer_weights']>
 
-save_metric_dir = '/home/k948d562/output/metrics/'
+# save the MinMaxScaler()
+with open(f"{save_model_dir}/scaler_{output_name}.pkl", "wb") as f:
+    pickle.dump(scaler, f)
+
+save_metric_dir = f'/home/k948d562/output/metrics/{output_name}'
 
 # Evaluate the test set
 print('METRICS:')

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -150,13 +150,13 @@ history = utils.model.train_model(model_regCNN,
                                   data_train,
                                   data_val,
                                   args.epochs,
-                                  64)
+                                  128)
 
 # save the history to a pandas dataframe, will append the evaluate() output to this dataframe
 metrics = pd.DataFrame(history.history)
 
 # the default output name
-output_name = '_{}epochs_{}_{}_{}_{}_XYZ'.format(args.epochs, det, horn, flux, date.today())
+output_name = '{}epochs_{}_{}_{}_{}_XYZ'.format(args.epochs, det, horn, flux, date.today())
 
 # save the model
 save_model_dir = '/home/k948d562/output/trained-models/'

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -39,8 +39,8 @@ print('data_train_path: ', train_path)
 datasets, total_events, total_files = io.load_data(train_path, False)
 
 print('========================================')
-# convert the lists to numpy arrays
-datasets = dp.convert_lists_to_nparray(datasets)
+# Convert all lists in datasets to NumPy arrays with dtype=object (while keeping the arrays within from each file arrays)
+datasets = {key: np.array(value, dtype=object) for key, value in datasets.items()}
 print('to access FILE, index in array is: (cvnmap.shape[0] = ', datasets['cvnmap'].shape[0], 'files.)')  # first dimension is the file
 
 # trust that they are all numpy.arrays AND have the right shape

--- a/utils/data_processing.py
+++ b/utils/data_processing.py
@@ -48,16 +48,6 @@ def convert_nd_vtx_y_to_pixelmap(vtx_y_array, firstcelly_array):
 def convert_nd_vtx_z_to_pixelmap(vtx_z_array, firstplane_array):
     return vtx_z_array / 6.61 - firstplane_array
 
-def convert_lists_to_nparray(dsets) -> dict:
-    """
-    Convert the lists in dsets to numpy arrays
-    :param dsets:
-    :return:
-    """
-    print("Converting to lists in 'datasets' to numpy array...")
-    dsets = {key: array(dsets[key]) for key in dsets}
-    return dsets
-
 
 def print_input_data(d_tr, d_te, d_va) -> None:
     """
@@ -101,13 +91,13 @@ class ConvertFarDetCoords:
 
     def convert_pixelmap_to_fd_vtx(self, pixelmap_array, first_hit_array):
         if self.coordinate in self.c_map_to_vtx.keys():
-            return self.c_map_to_vtx[self.coordinate](pixelmap_array, first_hit_array)
+            return array(self.c_map_to_vtx[self.coordinate](pixelmap_array, first_hit_array))
         else:
             raise ValueError(f'Coordinate {self.coordinate} is not valid.')
 
     def convert_fd_vtx_to_pixelmap(self, vtx_array, first_hit_array):
         if self.coordinate in self.c_map_to_pixelmap.keys():
-            return self.c_map_to_pixelmap[self.coordinate](vtx_array, first_hit_array)
+            return array(self.c_map_to_pixelmap[self.coordinate](vtx_array, first_hit_array))
         else:
             raise ValueError(f'Coordinate {self.coordinate} is not valid.')
 
@@ -236,6 +226,7 @@ class DataCleaning:
         rows_to_drop = where(~filter_cvnmap)[0]
         print(f"Rows to keep, {len(rows_to_keep)} : {rows_to_keep}")
         print(f"Rows to drop, {len(rows_to_drop)} : {rows_to_drop}")
+        print(f"That's {len(rows_to_keep)/len(rows_to_keep)*100:.2f}% of the rows to keep.")
 
         return {"keep": rows_to_keep, "drop": rows_to_drop}
 

--- a/utils/data_processing.py
+++ b/utils/data_processing.py
@@ -226,7 +226,7 @@ class DataCleaning:
         rows_to_drop = where(~filter_cvnmap)[0]
         print(f"Rows to keep, {len(rows_to_keep)} : {rows_to_keep}")
         print(f"Rows to drop, {len(rows_to_drop)} : {rows_to_drop}")
-        print(f"That's {len(rows_to_keep)/len(rows_to_keep)*100:.2f}% of the rows to keep.")
+        print(f"That's {len(rows_to_drop)/(len(rows_to_keep) + len(rows_to_drop))*100:.1f}% of the rows to drop.")
 
         return {"keep": rows_to_keep, "drop": rows_to_drop}
 

--- a/utils/iomanager.py
+++ b/utils/iomanager.py
@@ -80,10 +80,8 @@ class IOManager:
         det, horn, flux = '', '', ''
         print("Determining the 'det', 'horn', 'flux' with string........:", nova_string)
         if 'FD' in nova_string:
-            print('I found `FD`.')
             det = 'FD'
         elif 'ND' in nova_string:
-            print('I found `ND`.')
             det = 'ND'
         else:
             print('ERROR. I did not find a detector exiting......')
@@ -93,27 +91,23 @@ class IOManager:
         # Get horn...
         print('Determining the horn...')
         if 'FHC' in nova_string:
-            print('I found `FHC`.')
             horn = 'FHC'
         elif 'RHC' in nova_string:
-            print('I found `RHC`.')
             horn = 'RHC'
         else:
             print('ERROR. I did not find a horn, exiting......')
             exit()
-        print('horn: {}'.format(horn))
+        print('HORN: {}'.format(horn))
 
         # Get flux...
         print('Determining the flux...')
         if 'Fluxswap' in nova_string:
-            print('I found `Fluxswap`.')
             flux = 'Fluxswap'
         elif 'Nonswap' in nova_string:
-            print('I found `Nonswap`.')
             flux = 'Nonswap'
         else:
             print('ERROR. I did not find a flux, exiting......')
             exit()
-        print('flux: {}'.format(flux))
+        print('FLUX: {}'.format(flux))
 
         return det, horn, flux

--- a/utils/model.py
+++ b/utils/model.py
@@ -98,8 +98,8 @@ class Config:
     @staticmethod
     def assemble_model_output(model_xz, model_yz) -> Model:
         input_shape = (100, 80, 1)
-        input_xz = Input(shape=input_shape)
-        input_yz = Input(shape=input_shape)
+        input_xz = Input(shape=input_shape, name='xz')
+        input_yz = Input(shape=input_shape, name='yz')
 
         # get outputs from the Sequential models, one from each view.
         output_xz = model_xz(input_xz)
@@ -157,11 +157,11 @@ def train_model(model_output,
     """
     start = time.time()
     history = model_output.fit(
-        x={'data_train_xz': data_training['xz'], 'data_train_yz': data_training['yz']},
+        x={'xz': data_training['xz'], 'yz': data_training['yz']},
         y=data_training['vtx'],
         epochs=epochs,
         batch_size=batch_size,
-        validation_data=({'data_val_xz': data_validation['xz'], 'data_val_yz': data_validation['yz']}, data_validation['vtx']))
+        validation_data=({'xz': data_validation['xz'], 'yz': data_validation['yz']}, data_validation['vtx']),
 
     stop = time.time()
     elapsed = (stop - start) / 60
@@ -178,10 +178,12 @@ def evaluate_model(model_output, data_testing, filtered_events, evaluate_dir):
     :return: evaluation: array (single values for each metric)
     """
     start_eval = time.time()
+        x={'xz': data_train['xz'], 'yz': data_train['yz']},
     print('Evaluation on the test set...')
     evaluation = model_output.evaluate(
         x={'data_test_xz': data_testing['xz'], 'data_test_yz': data_testing['xz']},
         y=data_testing['vtx'])
+        x={'xz': data_test['xz'], 'yz': data_test['yz']},
     stop_eval = time.time()
     print('Test Set Evaluation: {}'.format(evaluation))
     print('Evaluation time: ', stop_eval - start_eval)


### PR DESCRIPTION
Tied to Issue #14. 

Several improvements to training and changes to go with Python 3.11 & TF 2.15.0 update:

* Stop using the `.python` imports and using the public `keras` API. 
* Added MinMaxScaler() to features (cvnmaps) , and transform() all data.
* save scaler to pkl file and load it for data to model.predict() on.
* reduce memory where possible:
  -- precision to float16 
  -- operate in place where possible to minimize memory (done for both full training and test-size training).

* input layer must be named now. 
* add Early Stopping
* modify whats saved after evalution() 
* Update the sbatch generation script to point to Python 3.11 system installation and use correct python virtual env & increase memory request slightly, since we are still below the max.  
* Added some clean up of the 1D resolution plotting as well. 