### PR TITLE
Currently, using MinMaxScaler() -- and thus floats -- even of the lowest precision is too much memory to fit on 2019 GPUs. We observe no degradation in performance using ints, so drop them for now.

### DIFF
--- a/Prod5.1-FD/model-prediction/model_predict_coordinates_xyz.py
+++ b/Prod5.1-FD/model-prediction/model_predict_coordinates_xyz.py
@@ -16,7 +16,6 @@ import utils.iomanager as io
 import argparse
 import numpy as np
 import pandas as pd
-import pickle
 from tensorflow.keras.models import load_model
 import os
 import time
@@ -149,23 +148,7 @@ cvnmap_yz = datasets['cvnmap'][:, :, :, 1].reshape(datasets['cvnmap'].shape[0], 
 print('cvnmap_xz.shape ', cvnmap_xz.shape)
 print('cvnmap_yz.shape ', cvnmap_yz.shape)
 print('========================================')
-
-pkl_path = args.model_file.replace('model_', 'scaler_').replace('.h5', '.pkl')  # this is the full path
-print('Loading pickle file for MinMaxScaler().....')
-with open(f'{pkl_path}', 'rb') as f:
-    scaler = pickle.load(f)
-print('transform()-ing the XZ and YZ views.....  ')
-# Ensure they have the same shape structure
 assert cvnmap_xz.shape == cvnmap_yz.shape, "Shapes of cvnmap_xz and cvnmap_yz must match."
-
-# Transform the scaler on combined training data
-scaled_data = scaler.transform(np.vstack([
-                cvnmap_xz.reshape(cvnmap_xz.shape[0], -1),  # Flatten spatial dimensions
-                cvnmap_yz.reshape(cvnmap_yz.shape[0], -1)
-]))
-# Split the scaled data back into XZ and YZ
-cvnmap_xz[:] = scaled_data[:cvnmap_xz.shape[0]].reshape(cvnmap_xz.shape[0], 100, 80, 1)
-cvnmap_yz[:] = scaled_data[cvnmap_xz.shape[0]:].reshape(cvnmap_yz.shape[0], 100, 80, 1)
 print('========================================')
 
 

--- a/Prod5.1-FD/training/xyz_vertex_training.py
+++ b/Prod5.1-FD/training/xyz_vertex_training.py
@@ -17,7 +17,6 @@ from datetime import date
 import numpy as np
 import os
 import pandas as pd
-import pickle
 from tensorflow.keras.optimizers import Adam  # optimizer
 from sklearn.metrics import mean_squared_error, mean_absolute_error, explained_variance_score, r2_score
 import time
@@ -112,9 +111,9 @@ cvnmap_xz = cvnmap_xz[keep_drop_evts['keep']]
 cvnmap_yz = cvnmap_yz[keep_drop_evts['keep']]
 assert cvnmap_xz.shape[0] == cvnmap_yz.shape[0] == vtx_coords.shape[0]
 
+cvnmap_xz = cvnmap_xz.astype(np.uint8)
+cvnmap_yz = cvnmap_yz.astype(np.uint8)
 vtx_coords = vtx_coords.astype(np.float16)
-cvnmap_xz = cvnmap_xz.astype(np.float16)
-cvnmap_yz = cvnmap_yz.astype(np.float16)
 
 
 # #### Prepare the Training & Test Sets
@@ -140,9 +139,6 @@ model_regCNN = utils.model.Config.assemble_model_output(model_xz, model_yz)
 utils.model.Config.compile_model(model_regCNN)
 print(model_regCNN.summary())
 
-scaler, data_train, data_val, data_test = utils.model.Config.transform_data(data_train,
-                                                                            data_val,
-                                                                            data_test)
 
 dp.print_input_data(data_train, data_test, data_val)
 
@@ -164,10 +160,6 @@ save_model_dir = '/home/k948d562/output/trained-models/'
 model_regCNN.save(save_model_dir + 'model_{}.h5'.format(output_name))
 print('saved model to: ', save_model_dir + 'model_{}.h5'.format(output_name))
 # Items in the model file: <KeysViewHDF5 ['model_weights', 'optimizer_weights']>
-
-# save the MinMaxScaler()
-with open(f"{save_model_dir}/scaler_{output_name}.pkl", "wb") as f:
-    pickle.dump(scaler, f)
 
 save_metric_dir = f'/home/k948d562/output/metrics/{output_name}'
 


### PR DESCRIPTION
we should try this training on gpu202401. If this works, we can keep this code, but at the moment, it hasn't been tested on gpu202401 -- so we remove it. 

See PR #18 for details about testing